### PR TITLE
Added apparently missing parameter name

### DIFF
--- a/fmapper/command.py
+++ b/fmapper/command.py
@@ -1131,7 +1131,7 @@ class measure_orientation_contrast(UnitCurveCommand):
     """
 
     metafeature_fns = param.HookList(
-        default=[contrast2centersurroundscale.instance('weber_contrast')])
+        default=[contrast2centersurroundscale.instance(contrast_parameter='weber_contrast')])
 
     pattern_generator = param.Callable(
         default=OrientationContrast(surround_orientation_relative=True))


### PR DESCRIPTION
A bug masked by a bug in param.ParameterizedFunction.instance()? See https://github.com/ioam/param/issues/48.
