### PR TITLE
Fix measure_dr_pref

### DIFF
--- a/featuremapper/__init__.py
+++ b/featuremapper/__init__.py
@@ -414,7 +414,7 @@ class FeatureResponses(PatternDrivenAnalysis):
             f_vals = mvals[1:]
             act = self._activities[name][f_vals]
             for feature, value in current_values:
-                self._featureresponses[name][f_vals][feature].update(act, value)
+                self._featureresponses[name][f_vals][feature.lower()].update(act, value)
             if p.store_responses:
                 cn, cv = zip(*current_values)
                 key = (timestamp,)+f_vals+cv

--- a/featuremapper/command.py
+++ b/featuremapper/command.py
@@ -664,7 +664,7 @@ class measure_dr_pref(SinusoidalMeasureResponseCommand):
 
         return [f.Speed(values=[0]) if p.num_speeds is 0 else
                 f.Speed(range=(0.0, p.max_speed), steps=p.num_speeds),
-                f.Duration(values=np.max(p.durations)),
+                f.Duration(values=[np.max(p.durations)]),
                 f.Frequency(values=p.frequencies),
                 f.Direction(steps=p.num_direction,
                             preference_fn=self.preference_fn),

--- a/featuremapper/features.py
+++ b/featuremapper/features.py
@@ -106,7 +106,7 @@ Ocular           = Integer("Ocular")
 Speed            = Float("Speed")
 
 # Time features
-Time     = Dimension("Time", type=param.Dynamic.time_fn.time_type)
+Time     = Feature("Time", type=param.Dynamic.time_fn.time_type)
 Duration = Time("Duration")
 
 Feature._init = True # All Features created externally have to supply range or values


### PR DESCRIPTION
This pull request fixes measure_dr_pref, which previously resulted in an error. This was because _feature_list in measure_dr_pref should return a list of Features, however the used Duration was a subclass of Dimension rather than Feature.

This change then needs values to be a list rather than float.

Finally, an unrelated error occurred when using 

> Orientation(values=or_values, compute_fn=compute_orientation_from_direction)

Because compute_fn is used, the name of this object is used in line 347 of __init__.py:

> complete_settings = permuted_settings +\
>                            [(f.name, f.compute_fn(permuted_settings))
>                             for f in self.features_to_compute]

This results in "Orientation". However, the lower-case name is expected in _featureresponses.

I don't know whether it is best to put the lower() where it is currently or changing

> f.name

in

> f.name.lower()

Best, Tobias
