### PR TITLE
Added code for new multichannel retina

### DIFF
--- a/featuremapper/metaparams.py
+++ b/featuremapper/metaparams.py
@@ -215,8 +215,9 @@ class hue2rgbscaleNewRetina(param.ParameterizedFunction):
             r,g,b = hue_to_rgb((features['hue'],sat_for_analysis,1.0))
 
             for name in inputs.keys():
-                inputs[name] = ComposeChannels(generators=[inputs[name]]*3,
-                                     channel_transforms = [ScaleChannels(channel_factors = [r, g, b])])
+                inputs[name] = ComposeChannels(
+                    generators=[inputs[name]]*3,
+                    channel_transforms = [ScaleChannels(channel_factors = [r, g, b])])
 
 
 
@@ -254,10 +255,12 @@ class ocular2leftrightscaleNewRetina(param.ParameterizedFunction):
             for name in inputs.keys():
                 if (name.count('Right')):
                     inputs[name] = ComposeChannels(generators=[inputs[name]]*3,
-                                     channel_transforms = [ScaleChannels(channel_factors=[oc, oc, oc])])
+                                     channel_transforms =
+                                        [ScaleChannels(channel_factors=[oc, oc, oc])])
                 elif (name.count('Left')):
                     inputs[name] = ComposeChannels(generators=[inputs[name]]*3,
-                                     channel_transforms = [ScaleChannels(channel_factors=[1.0-oc, 1.0-oc, 1.0-oc])])
+                                     channel_transforms =
+                                        [ScaleChannels(channel_factors=[1.0-oc, 1.0-oc, 1.0-oc])])
                 else:
                     self.warning('Skipping input region %s; Ocularity is defined '
                                  'only for Left and Right retinas.' % name)


### PR DESCRIPTION
This PR introduces two new classes related to measurement code for the new multichannel retina.
The hue measurement code is written by Giacomo Spigler. Using the same principles, I adapted this code to also work with ocularity.

As mentioned in https://github.com/ioam/topographica/pull/584, Giacomo mentioned once that he has some code which make these classes obsolete, by checking whether the input is a multichannel object. However, I have not heard from him regarding this issue since then. It would be great, if Giacomo finalizes this code.
