### PR TITLE
Made Duration a Feature

### DIFF
--- a/featuremapper/analysis/hypercolumns.py
+++ b/featuremapper/analysis/hypercolumns.py
@@ -141,7 +141,7 @@ class PowerSpectrumAnalysis(TreeOperation):
 
         info_table = ItemTable(sorted(info.items()), group='PowerSpectrum Analysis', label=preference.label)
         curve = Curve(samples, kdims=[wavenumber_dim], label=preference.label, group='FFTPowerFit')
-        hist = Histogram(amplitudes, edges, kdims=[wavenumber_dim],
+        hist = Histogram((edges, amplitudes), kdims=[wavenumber_dim],
                          label=preference.label, group='FFTPowerHistogram')
 
 

--- a/featuremapper/command.py
+++ b/featuremapper/command.py
@@ -560,7 +560,7 @@ class measure_sine_pref(SinusoidalMeasureResponseCommand):
             [f.Speed(values=[0])]
 
         if p.num_direction > 0 and p.num_speeds > 0: features += \
-            [f.Speed(range=(0.0, p.max_speed), steps=p.num_speeds)]
+            [f.Speed(range=(0.0, p.max_speed), steps=p.num_speeds), f.Duration(values=[np.max(p.durations)])]
 
         if p.num_direction > 0:
             # Compute orientation from direction

--- a/featuremapper/features.py
+++ b/featuremapper/features.py
@@ -114,6 +114,6 @@ Speed            = Float("Speed")
 
 # Time features
 Time     = Dimension("Time", type=param.Dynamic.time_fn.time_type)
-Duration = Time("Duration")
+Duration = Feature("Duration", type=param.Dynamic.time_fn.time_type, preference_fn=None)
 
 Feature._init = True # All Features created externally have to supply range or values


### PR DESCRIPTION
Several places in the code expected Duration to have a `preference_fn` attribute.
I figured that deriving Duration from Feature and giving it a null value to be the safest way to do this.
In addition, the `measure_sine_pref` was missing the Duration feature.